### PR TITLE
Run the test suite with a single process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest -n ${{ steps.cpus.outputs.count }} --cov=pyxem --runslow --pyargs pyxem --durations=50 --timeout=360
+          pytest -n 1 --cov=pyxem --runslow --pyargs pyxem --durations=50 --timeout=360
 
       - name: Generate line coverage
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/pyxem/tests/signals/test_indexation_results.py
+++ b/pyxem/tests/signals/test_indexation_results.py
@@ -368,7 +368,6 @@ class TestOrientationResult:
         with pytest.raises(ValueError):
             rotations = orientations.to_crystal_map()
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="Very Slow on Windows")
     @pytest.mark.parametrize("add_vector_markers", [False, True])
     @pytest.mark.parametrize("add_ipf_markers", [False, True])
     @pytest.mark.parametrize("add_ipf_correlation_heatmap", [False, True])
@@ -395,7 +394,6 @@ class TestOrientationResult:
             vector_kwargs=vector_kwargs,
         )
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="Very Slow on Windows")
     @pytest.mark.parametrize("add_vector_markers", [False, True])
     @pytest.mark.parametrize("add_ipf_correlation_heatmap", [False, True])
     @pytest.mark.parametrize("add_ipf_colorkey", [False, True])
@@ -433,7 +431,6 @@ class TestOrientationResult:
         markers = orientations.to_ipf_correlation_heatmap_markers()
         assert all(isinstance(m, hs.plot.markers.Markers) for m in markers)
 
-    @pytest.mark.skipif(sys.platform == "win32", reason="Very Slow on Windows")
     def test_to_ipf_correlation_heatmap_markers_multi_phase(
         self, multi_phase_orientation_result
     ):


### PR DESCRIPTION
The very slow tests seems to work when running the test suite with a single process. I thought that I would try (because it is an easy check) but I don't know the reason! 😄 
